### PR TITLE
Add missing import

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,7 @@
 // Basically revert this commit:
 // https://git.gnome.org/browse/gnome-shell/commit/js/ui/overviewControls.js?id=2d849759c837ebc60f41022ce9ae83616ba0274e
 
+const Lang = imports.lang;
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
 const ThumbnailsSlider = imports.ui.overviewControls.ThumbnailsSlider;


### PR DESCRIPTION
Thank you for this nice extension! It is really annoying that the GS overview no longer is an overview. But then it's great that it can be fixed with an extension.

Lang was not imported resulting in an error when installing through extensions.gnome.org or after login.